### PR TITLE
add MySQL container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # go binary
 bin
+
+# MySQL container
+docker/mysql/data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: '3'
+
+services:
+  mysql:
+    image: mysql:5.7
+    container_name: mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: torimo
+      MYSQL_USER: torimo
+      MYSQL_PASSWORD: torimo
+      TZ: 'Asia/Tokyo'
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - ./docker/mysql/data:/var/lib/mysql
+      - ./docker/mysql/my.cnf:/etc/mysql/conf.d/my.cnf
+      - ./docker/mysql/sql:/docker-entrypoint-initdb.d
+    ports:
+      - 3306:3306

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,1 @@
+# TODO: Define torimo-article-api container

--- a/docker/mysql/sql/schema.sql
+++ b/docker/mysql/sql/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS `test_articles` (
+    `id` INT NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(32) BINARY UNIQUE,
+    `title` VARCHAR(32),
+    PRIMARY KEY (`id`)
+);
+
+INSERT INTO test_articles(name, title) VALUE('admin', 'torimo');


### PR DESCRIPTION
## レビューよろしくお願いします🙏
​
## Refs: 関連ファイル
​
## Why: なぜこの変更をするのか
RDBMSとの接続が必要な機能の実装の際に必要。
​
## What: 何をどう変更したのか
### docker-compose.yamlの追加
MySQLコンテナを起動(mysql -u root -p -h 127.0.0.1で接続可能)
### docker/ディレクトリの追加
DBの初期化
​
## Affected range: この変更によりどこが影響を受けるのか
Nothing
​
## Point: レビュアーは何を確認すればいいのか
​`docker-compose up -d` で動作確認
​
## Other: その他
- WIP: torimo-article-apiのコンテナ化
  - `gorm`実装時に追加する予定