### PR TITLE
add depends_on into docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,8 @@ services:
       - .:/app
     ports:
       - 8080:8080
+    depends_on:
+      - mysql
 
   mysql:
     image: mysql:5.7


### PR DESCRIPTION
## レビューよろしくお願いします🙏
​
## Refs: 関連ファイル
​
* Redmine ticket: link
* Google doc: link
* Others: link
​
## Why: なぜこの変更をするのか
​
MySQLコンテナの起動の前にAPIが起動してしまう現象への対応
​
## What: 何をどう変更したのか
​
`depends_on`を追加することで起動順序を制御するようにした

より詳細に制御をする場合は下記ドキュメントを参照

https://docs.docker.com/compose/startup-order/
​
## Affected range: この変更によりどこが影響を受けるのか
​
## Point: レビュアーは何を確認すればいいのか
​
## Other: その他