### PR TITLE
fix docker workdir for create go binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM golang:1.13.7-alpine3.11
 
-WORKDIR /app
+WORKDIR /torimo-article-api
 
 ENV GO111MODULE=on
 
 COPY . .
 
-CMD ["go", "run", "src/main.go"]
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build src/*.go
+
+CMD ["./main"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,9 +10,7 @@ services:
       DB_URL: mysql:3306
     build: .
     image: article:${VERSION}
-    working_dir: "/app"
-    volumes:
-      - .:/app
+    working_dir: "/torimo-article-api"
     ports:
       - 8080:8080
     depends_on:


### PR DESCRIPTION
## レビューよろしくお願いします🙏
​
## Refs: 関連ファイル
​​
## Why: なぜこの変更をするのか
​
Running `torimo-article-api` by go binary, docker container runs more faster than before.
​
## What: 何をどう変更したのか
### Dockerfile
For importing packages, `WORKDIR` changes to `/torimo-article-api` (from `/app`).
### docker-compose.yaml
- `working_dir` changes by the above-mentioned change.
- Delete a wasted setting.
​
## Affected range: この変更によりどこが影響を受けるのか
This pull request has no affection to the program.

## Point: レビュアーは何を確認すればいいのか
​Please run the docker container once.
​
## Other: その他
Nothing.